### PR TITLE
Fix bug: openedByMe does not show up

### DIFF
--- a/ZuggerWpf/Action/GetBug.cs
+++ b/ZuggerWpf/Action/GetBug.cs
@@ -50,36 +50,39 @@ namespace ZuggerWpf
 
                             foreach (var j in jsArray)
                             {
-                                BugItem bi = new BugItem()
+                                if (j["status"].Value<string>() != "closed" && j["status"].Value<string>() != "resolved")
                                 {
-                                    priority = j["pri"].Value<string>()
+                                    BugItem bi = new BugItem()
+                                    {
+                                        priority = j["pri"].Value<string>()
                                     ,
-                                    Severity = j["severity"].Value<string>()
+                                        Severity = j["severity"].Value<string>()
                                     ,
-                                    ID = j["id"].Value<int>()
+                                        ID = j["id"].Value<int>()
                                     ,
-                                    Title = Util.EscapeXmlTag(j["title"].Value<string>())
+                                        Title = Util.EscapeXmlTag(j["title"].Value<string>())
                                     ,
-                                    OpenDate = j["openedDate"].Value<string>()
+                                        OpenDate = j["openedDate"].Value<string>()
                                     ,
-                                    LastEdit = j["lastEditedDate"].Value<string>()
+                                        LastEdit = j["lastEditedDate"].Value<string>()
                                     ,
-                                    Tip = "Bug"
-                                };
+                                        Tip = "Bug"
+                                    };
 
-                                if (!ItemCollectionBackup.Contains(bi.ID))
-                                {
-                                    NewItemCount = NewItemCount == 0 ? bi.ID : (NewItemCount > 0 ? -2 : NewItemCount - 1);
+                                    if (!ItemCollectionBackup.Contains(bi.ID))
+                                    {
+                                        NewItemCount = NewItemCount == 0 ? bi.ID : (NewItemCount > 0 ? -2 : NewItemCount - 1);
+                                    }
+
+                                    itemsList.Add(bi);
                                 }
-
-                                itemsList.Add(bi);                                
                             }
 
                             if (OnNewItemArrive != null
                                 && NewItemCount != 0)
                             {
                                 OnNewItemArrive(ItemType.Bug, NewItemCount);
-                            }                            
+                            }
                         }
 
                         isSuccess = true;

--- a/ZuggerWpf/Action/GetOpenedByMeBug.cs
+++ b/ZuggerWpf/Action/GetOpenedByMeBug.cs
@@ -71,7 +71,7 @@ namespace ZuggerWpf
                                 foreach (var j in jsArray)
                                 {
                                     //openedbyme 显示未关闭
-                                    if (j["status"].Value<string>() != "closed")
+                                    if (j["status"].Value<string>() != "closed" && j["status"].Value<string>() != "resolved")
                                     {
                                         BugItem bi = new BugItem()
                                         {

--- a/ZuggerWpf/ApplicationConfig.cs
+++ b/ZuggerWpf/ApplicationConfig.cs
@@ -100,7 +100,7 @@ namespace ZuggerWpf
         {
             get
             {
-                return Util.URLCombine(pmsHost, IsPATH_INFORequest ? "bug-browse-{0}-openedByMe-1-id_desc-0-2147483647-1.json?a=1"
+                return Util.URLCombine(pmsHost, IsPATH_INFORequest ? "bug-browse-{0}-0-openedByMe-id_desc-0-2147483647.json?a=1"
                     : "?m=bug&f=browse&productID={0}&browseType=openedByMe&param=0&orderBy=id_desc&recTotal=0&recPerPage=2147483647&pageID=1&t=json");
             }          
         }

--- a/ZuggerWpf/Properties/AssemblyInfo.cs
+++ b/ZuggerWpf/Properties/AssemblyInfo.cs
@@ -12,7 +12,7 @@ using System.Windows;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Zugger")]
-[assembly: AssemblyCopyright("Copyright © 鲍毅铭 2010 - 2011")]
+[assembly: AssemblyCopyright("Copyright © 鲍毅铭 2010 - 2017")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -51,5 +51,5 @@ using System.Windows;
 // 可以指定所有这些值，也可以使用“内部版本号”和“修订号”的默认值，
 // 方法是按如下所示使用“*”:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.1.0")]
-[assembly: AssemblyFileVersion("1.5.1.0")]
+[assembly: AssemblyVersion("1.5.2.0")]
+[assembly: AssemblyFileVersion("1.5.2.0")]

--- a/ZuggerWpf/ZuggerWpf.csproj
+++ b/ZuggerWpf/ZuggerWpf.csproj
@@ -14,7 +14,7 @@
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
-    <ApplicationIcon>zugger.ico</ApplicationIcon>
+    <ApplicationIcon>if_Z Brush_51169.ico</ApplicationIcon>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>
@@ -169,6 +169,7 @@
     <AppDesigner Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <Resource Include="if_Z Brush_51169.ico" />
     <Content Include="Lib\log4net.dll" />
     <Content Include="Lib\Newtonsoft.Json.dll" />
     <Content Include="Resources\Notify.wav">


### PR DESCRIPTION
Reason:
  The API changed. See ApplicationConfig.GetOpenedByMeBugUrl for detail.
Note:
  The fix is applicable for PATH_INFORequest, i.e. the URL looks like
  http://pro.demo.zentao.net/bug-view-40.html
  There are hyphens between module and ID.